### PR TITLE
 Dependency cleanup & copy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,53 +38,28 @@
                                                         
 
    <build>
-      <plugins>
-         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.3</version>
-            <configuration>
-               <source>1.8</source>
-               <target>1.8</target>
-               <downloadSources>true</downloadSources>
-               <downloadJavadocs>true</downloadJavadocs>
-            </configuration>
-         </plugin>
-         <!--
-         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-shade-plugin</artifactId>
-            <version>2.3</version>
-            <executions>
-               <execution>
-                  <phase>package</phase>
-                  <goals>
-                     <goal>shade</goal>
-                  </goals>
-                  <configuration>
-                     <artifactSet>
-                        <includes>
-                           <include>net.clearvolume:cleargl</include>
-                           <include>net.clearvolume:clearcuda</include>
-                           <include>net.clearvolume:clearvolume</include> 
-                           <include>net.coremem:CoreMem</include>
-                          
-                           <include>org.jogamp.gluegen:gluegen-rt</include>
-                           <include>org.jogamp.jogl:jogl-all</include>
-                        </includes>
-                     </artifactSet>
-                     <relocations>
-                        <relocation>
-                           <pattern>javax.media.opengl</pattern>
-                           <shadedPattern>cv.javax.media.opengl</shadedPattern>
-                        </relocation>
-                     </relocations>            
-                  </configuration>
-               </execution>
-            </executions>
-         </plugin>
-         -->
-      </plugins>
+       <plugins>
+           <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-dependency-plugin</artifactId>
+               <configuration>
+                   <outputDirectory>
+                       ${project.build.directory}/cv_dependencies
+                   </outputDirectory>
+               </configuration>
+           </plugin>
+           <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-compiler-plugin</artifactId>
+               <version>3.3</version>
+               <configuration>
+                   <source>1.8</source>
+                   <target>1.8</target>
+                   <downloadSources>true</downloadSources>
+                   <downloadJavadocs>true</downloadJavadocs>
+               </configuration>
+           </plugin>
+       </plugins>
    </build>
 
    <dependencies>
@@ -119,18 +94,6 @@
          <artifactId>clearcuda</artifactId>
          <version>0.9.4</version>
       </dependency>
-      <!-- 
-      <dependency>
-         <groupId>org.jogamp.gluegen</groupId>
-         <artifactId>gluegen-rt</artifactId>
-         <version>2.3.1</version>
-      </dependency>
-      <dependency>
-         <groupId>org.jogamp.jogl</groupId>
-         <artifactId>jogl-all</artifactId>
-         <version>2.3.1</version>
-      </dependency>
-     --> 
       <dependency>
          <groupId>org.micromanager</groupId>
          <artifactId>MMJ_</artifactId>


### PR DESCRIPTION
Hey Nico,

I changed few bits in the pom:
- added the maven-dependency plugin, so running `mvn dependency:copy-dependencies` copies all dependent JARs into `$target/cv_dependencies`. These files can then be copied in `jars/ClearVolume` dir of MM2 so MM2 can then be run with ClearVolume by `java -cp 'jars/ClearVolume/*:ij.jar’ ij.ImageJ` -- as discussed on gitter
- I also took the liberty to remove the jogl jars, as they are not needed in the plugin
